### PR TITLE
Qiita 記事一覧ページを追加 (/articles)

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+import { ArticlesPage } from '@/components/pages/ArticlesPage';
+import { buildPageMetadata } from '@/libs/i18n/metadata';
+
+export const metadata: Metadata = buildPageMetadata({ locale: 'ja', page: 'articles', path: '/articles' });
+
+export default function Page() {
+  return <ArticlesPage locale="ja" />;
+}

--- a/app/en/articles/page.tsx
+++ b/app/en/articles/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+import { ArticlesPage } from '@/components/pages/ArticlesPage';
+import { buildPageMetadata } from '@/libs/i18n/metadata';
+
+export const metadata: Metadata = buildPageMetadata({ locale: 'en', page: 'articles', path: '/articles' });
+
+export default function Page() {
+  return <ArticlesPage locale="en" />;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,7 @@ const lastModified = {
   home: '2026-06-13',
   awards: '2026-06-13',
   projects: '2026-06-13',
+  articles: '2026-06-30',
   gallery: '2026-06-13',
   colophon: '2026-06-13',
 };
@@ -24,6 +25,7 @@ interface RouteEntry {
 const routes: RouteEntry[] = [
   { path: '', changeFrequency: 'monthly', priority: 1.0, lastModified: lastModified.home },
   { path: '/projects', changeFrequency: 'monthly', priority: 0.9, lastModified: lastModified.projects },
+  { path: '/articles', changeFrequency: 'weekly', priority: 0.85, lastModified: lastModified.articles },
   { path: '/awards', changeFrequency: 'monthly', priority: 0.8, lastModified: lastModified.awards },
   { path: '/gallery', changeFrequency: 'monthly', priority: 0.7, lastModified: lastModified.gallery },
   { path: '/colophon', changeFrequency: 'yearly', priority: 0.3, lastModified: lastModified.colophon },

--- a/components/features/articles/ArticleCard.tsx
+++ b/components/features/articles/ArticleCard.tsx
@@ -1,0 +1,57 @@
+import { ArrowUpRight, ThumbsUpIcon } from 'lucide-react';
+
+import { type Locale, type Localized, pickLocalized } from '@/libs/i18n/locale';
+import type { QiitaArticle } from '@/types';
+
+interface ArticleCardProps {
+  article: QiitaArticle;
+  locale: Locale;
+}
+
+const DATE_LOCALES: Localized<string> = { ja: 'ja-JP', en: 'en-US' };
+
+function formatDate(iso: string, locale: Locale): string {
+  return new Date(iso).toLocaleDateString(pickLocalized(DATE_LOCALES, locale), {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+export function ArticleCard({ article, locale }: ArticleCardProps) {
+  return (
+    <a
+      href={article.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex h-full flex-col gap-3 rounded-xl border border-warm-border bg-warm-surface p-5 transition-[transform,border-color,box-shadow] duration-300 hover:-translate-y-1 hover:border-warm-accent/30 hover:shadow-lg hover:shadow-warm-accent/5 focus-visible:ring-2 focus-visible:ring-warm-accent focus-visible:outline-none"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="font-mono text-xs text-warm-subtext">{formatDate(article.createdAt, locale)}</p>
+        <ArrowUpRight
+          aria-hidden="true"
+          className="h-4 w-4 shrink-0 text-warm-subtext transition-colors group-hover:text-warm-accent"
+        />
+      </div>
+
+      <h2 className="font-heading text-base font-semibold leading-snug text-warm-text transition-colors group-hover:text-warm-accent">
+        {article.title}
+      </h2>
+
+      {article.tags.length > 0 && (
+        <ul aria-label="tags" className="mt-auto flex flex-wrap gap-1.5 pt-2">
+          {article.tags.map((tag) => (
+            <li key={tag} className="rounded-full bg-warm-accent/10 px-2 py-0.5 font-mono text-[11px] text-warm-accent">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-1 text-xs text-warm-subtext">
+        <ThumbsUpIcon aria-hidden="true" className="h-3.5 w-3.5" />
+        <span className="font-mono">{article.likesCount}</span>
+      </div>
+    </a>
+  );
+}

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AppWindowIcon, AwardIcon, BookOpenIcon, HomeIcon, ImagesIcon } from 'lucide-react';
+import { AppWindowIcon, AwardIcon, BookOpenIcon, FileTextIcon, HomeIcon, ImagesIcon } from 'lucide-react';
 
 import { LanguageSwitcher } from '@/components/layout/LanguageSwitcher';
 import { MobileMenu, type MobileMenuItem } from '@/components/layout/MobileMenu';
@@ -21,6 +21,11 @@ const NAVIGATION_ITEMS: MobileMenuItem[] = [
     path: '/projects',
     labelKey: 'nav.projects',
     icon: <AppWindowIcon aria-hidden="true" color="currentColor" size={32} strokeWidth={3} />,
+  },
+  {
+    path: '/articles',
+    labelKey: 'nav.articles',
+    icon: <FileTextIcon aria-hidden="true" color="currentColor" size={32} strokeWidth={3} />,
   },
   {
     path: '/gallery',

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Image } from '@heroui/image';
 import { Link } from '@heroui/link';
-import { AppWindowIcon, AwardIcon, BookOpenIcon, HomeIcon, ImagesIcon } from 'lucide-react';
+import { AppWindowIcon, AwardIcon, BookOpenIcon, FileTextIcon, HomeIcon, ImagesIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { BsGithub } from 'react-icons/bs';
 
@@ -21,6 +21,7 @@ const NAVIGATION_ITEMS: SidebarNavItem[] = [
   { path: '/', labelKey: 'nav.home', icon: <HomeIcon aria-hidden="true" size={20} /> },
   { path: '/awards', labelKey: 'nav.awards', icon: <AwardIcon aria-hidden="true" size={20} /> },
   { path: '/projects', labelKey: 'nav.projects', icon: <AppWindowIcon aria-hidden="true" size={20} /> },
+  { path: '/articles', labelKey: 'nav.articles', icon: <FileTextIcon aria-hidden="true" size={20} /> },
   { path: '/gallery', labelKey: 'nav.gallery', icon: <ImagesIcon aria-hidden="true" size={20} /> },
   { path: '/colophon', labelKey: 'nav.colophon', icon: <BookOpenIcon aria-hidden="true" size={20} /> },
 ];

--- a/components/layout/ThemeToggle.tsx
+++ b/components/layout/ThemeToggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useTheme } from 'next-themes';
 import { usePathname } from 'next/navigation';
+import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 import { BsFillMoonStarsFill, BsFillSunFill } from 'react-icons/bs';
 

--- a/components/pages/ArticlesPage.tsx
+++ b/components/pages/ArticlesPage.tsx
@@ -1,0 +1,25 @@
+import { BlockFrame } from '@/components/common/BlockFrame';
+import { ArticleCard } from '@/components/features/articles/ArticleCard';
+import { getQiitaArticles } from '@/libs/fetch/getQiitaArticles';
+import { t } from '@/libs/i18n/dictionaries';
+import type { Locale } from '@/libs/i18n/locale';
+
+interface ArticlesPageProps {
+  locale: Locale;
+}
+
+export async function ArticlesPage({ locale }: ArticlesPageProps) {
+  const articles = await getQiitaArticles();
+
+  return (
+    <div className="px-2 py-10 md:py-16">
+      <BlockFrame description={t(locale, 'articles.description')} title={t(locale, 'articles.title')}>
+        {articles.length === 0 ? (
+          <p className="col-span-full text-sm text-warm-subtext">{t(locale, 'articles.empty')}</p>
+        ) : (
+          articles.map((article) => <ArticleCard key={article.id} article={article} locale={locale} />)
+        )}
+      </BlockFrame>
+    </div>
+  );
+}

--- a/libs/fetch/getQiitaArticles.ts
+++ b/libs/fetch/getQiitaArticles.ts
@@ -1,0 +1,44 @@
+import type { QiitaArticle } from '@/types';
+
+const QIITA_USER = 'aida0710';
+const QIITA_API = `https://qiita.com/api/v2/users/${QIITA_USER}/items?per_page=100`;
+
+interface QiitaApiTag {
+  name: string;
+}
+
+interface QiitaApiItem {
+  id: string;
+  title: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  likes_count: number;
+  tags: QiitaApiTag[];
+}
+
+export async function getQiitaArticles(): Promise<QiitaArticle[]> {
+  try {
+    const response = await fetch(QIITA_API, {
+      headers: { Accept: 'application/json' },
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) return [];
+
+    const items = (await response.json()) as QiitaApiItem[];
+
+    return items
+      .map<QiitaArticle>((item) => ({
+        id: item.id,
+        title: item.title,
+        url: item.url,
+        createdAt: item.created_at,
+        likesCount: item.likes_count,
+        tags: item.tags.map((tag) => tag.name),
+      }))
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  } catch {
+    return [];
+  }
+}

--- a/libs/i18n/dictionaries.ts
+++ b/libs/i18n/dictionaries.ts
@@ -4,6 +4,7 @@ const ja = {
   'nav.home': 'Home',
   'nav.awards': 'Awards',
   'nav.projects': 'Projects',
+  'nav.articles': 'Articles',
   'nav.gallery': 'Gallery',
   'nav.colophon': 'Colophon',
 
@@ -42,6 +43,12 @@ const ja = {
   'projects.meta.title': 'Projects',
   'projects.meta.description': '自分が開発した又は携わったプロジェクト',
 
+  'articles.title': 'Articles',
+  'articles.description': 'Qiita に投稿した記事一覧',
+  'articles.meta.title': 'Articles',
+  'articles.meta.description': 'Qiita に投稿した記事の一覧',
+  'articles.empty': '記事を取得できませんでした',
+
   'gallery.title': 'Photo Gallery',
   'gallery.intro1': '私が撮影した写真や撮影していただいた写真を掲載しています。',
   'gallery.intro2': '画像をクリックすると拡大表示されます。',
@@ -74,6 +81,7 @@ const en: Partial<Record<DictionaryKey, string>> = {
   'nav.home': 'Home',
   'nav.awards': 'Awards',
   'nav.projects': 'Projects',
+  'nav.articles': 'Articles',
   'nav.gallery': 'Gallery',
   'nav.colophon': 'Colophon',
 
@@ -112,6 +120,12 @@ const en: Partial<Record<DictionaryKey, string>> = {
   'projects.description': 'Projects I have built or contributed to',
   'projects.meta.title': 'Projects',
   'projects.meta.description': 'Projects I have built or contributed to.',
+
+  'articles.title': 'Articles',
+  'articles.description': 'My posts on Qiita',
+  'articles.meta.title': 'Articles',
+  'articles.meta.description': 'A list of my articles on Qiita.',
+  'articles.empty': 'No articles could be loaded.',
 
   'gallery.title': 'Photo Gallery',
   'gallery.intro1': 'A collection of photos I have taken and photos taken of me.',

--- a/libs/i18n/metadata.ts
+++ b/libs/i18n/metadata.ts
@@ -4,7 +4,7 @@ import { siteConfig } from '@/config/site';
 import { type DictionaryKey, t } from '@/libs/i18n/dictionaries';
 import { EN_PREFIX, type Locale } from '@/libs/i18n/locale';
 
-type PageKey = 'awards' | 'projects' | 'gallery' | 'colophon';
+type PageKey = 'awards' | 'projects' | 'articles' | 'gallery' | 'colophon';
 
 interface BuildPageMetadataInput {
   locale: Locale;

--- a/types/index.ts
+++ b/types/index.ts
@@ -35,6 +35,16 @@ export interface Project {
   language: string;
 }
 
+// Qiita 記事関連の型
+export interface QiitaArticle {
+  id: string;
+  title: string;
+  url: string;
+  createdAt: string;
+  likesCount: number;
+  tags: string[];
+}
+
 // Skills 関連の型
 export interface SkillCategory {
   key: string;


### PR DESCRIPTION
## Summary

- `/articles` (`/en/articles`) に Qiita 投稿一覧ページを追加。Qiita API (`/users/aida0710/items`) を fetch し、**新しい順** で表示
- `next: { revalidate: 86400 }` で 1 日キャッシュ → 記事追加が **24h 以内にデプロイ無しで反映**。未認証 API (60 req/h) でこの用途には十分
- `ArticleCard` はタイトル / 投稿日 / タグ / LGTM を表示し、**カード全体が Qiita 記事への外部リンク** (`target="_blank"`, `rel="noopener noreferrer"`)。記事ページはサイト内にミラーしない
- 投稿日は locale に応じて `ja-JP` / `en-US` で整形
- Sidebar / MobileHeader のナビ項目に `Articles` を追加 (`FileTextIcon`)
- `buildPageMetadata` に `'articles'` を追加し、両ロケールで title / description / canonical / hreflang を適切に生成
- `sitemap.xml` に `/articles` と `/en/articles` を追加 (`changeFrequency: 'weekly'`)
- fetch 失敗時は空配列を返し、UI 側で `'articles.empty'` の代替テキストを表示

## Test plan

- [ ] `npm run build` がクリーンに通る
- [ ] `npm run lint` がクリーンに通る
- [ ] Vercel プレビューで `/articles` を開くと Qiita の記事一覧が新しい順で表示される
- [ ] `/en/articles` も同じ記事が表示され、UI ラベルと日付フォーマットが英語になる
- [ ] サイドバー / モバイルメニューに Articles 項目が現れ、各カードが Qiita 記事ページを新タブで開く
- [ ] `/sitemap.xml` に `/articles` と `/en/articles` が hreflang alternates 付きで含まれる
- [ ] Qiita 側で記事を投稿してから 24h 以内に一覧が更新される (ISR の挙動確認)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SskV26km9Riv33TeJE8xHY)_